### PR TITLE
fix: resolve RustSec advisories and clippy lints blocking CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,9 +1862,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -2125,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/src/chunking/parallel.rs
+++ b/src/chunking/parallel.rs
@@ -207,9 +207,7 @@ impl<C: Chunker + Clone + Send + Sync> Chunker for ParallelChunker<C> {
 // Add num_cpus as a simple function since we can't add dependencies mid-implementation
 mod num_cpus {
     pub fn get() -> usize {
-        std::thread::available_parallelism()
-            .map(std::num::NonZeroUsize::get)
-            .unwrap_or(4)
+        std::thread::available_parallelism().map_or(4, std::num::NonZeroUsize::get)
     }
 }
 

--- a/src/io/unicode.rs
+++ b/src/io/unicode.rs
@@ -238,8 +238,7 @@ pub fn split_sentences(s: &str) -> Vec<&str> {
 pub fn current_timestamp() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
+        .map_or(0, |d| d.as_secs() as i64)
 }
 
 #[cfg(test)]

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -118,8 +118,7 @@ impl SqliteStorage {
     fn now() -> i64 {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs() as i64)
-            .unwrap_or(0)
+            .map_or(0, |d| d.as_secs() as i64)
     }
 }
 


### PR DESCRIPTION
## Summary

Main CI is red due to advisories on transitive deps + new clippy 1.95 lints, blocking all open dependabot PRs (#186, #195, #199). This PR unblocks them.

- Bump `rustls-webpki` 0.103.9 → 0.103.13
  - RUSTSEC-2026-0099 (name-constraint bypass with wildcard names)
  - RUSTSEC-2026-0104 (reachable panic in CRL parsing)
- Bump `rand` 0.9.2 → 0.9.4
  - rand unsoundness with custom logger (`rand::rng()` aliased mutable refs)
- Replace `.map(f).unwrap_or(a)` with `.map_or(a, f)` in 3 sites per clippy 1.95 `map_unwrap_or`
  - `src/storage/sqlite.rs:119`
  - `src/chunking/parallel.rs:210`
  - `src/io/unicode.rs:239`

Both dependency bumps are patch-level, picked up via `cargo update -p <crate>` (lockfile-only).

## Test plan

- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo test --lib` — 341 passed, 0 failed, 2 ignored
- [ ] CI green
