### PR TITLE
ci: onboard attested delivery — provenance-attested, fail-closed-verified releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,10 +203,18 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  pin-check:
+    # Central reusable workflow: every `uses:` must be pinned to a 40-char SHA.
+    # Required-check context name: "pin-check / pin-check"
+    permissions:
+      contents: read
+    # yamllint disable-line rule:line-length
+    uses: zircote/.github/.github/workflows/pin-check.yml@e8f0dbde068cc0701e443e7b8d57ae9917de7da3  # main
+
   all-checks-pass:
     name: All Checks Pass
     if: always()
-    needs: [fmt, clippy, test, doc, deny, msrv]
+    needs: [fmt, clippy, test, doc, deny, msrv, pin-check]
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs passed
@@ -217,13 +225,15 @@ jobs:
           DOC_RESULT: ${{ needs.doc.result }}
           DENY_RESULT: ${{ needs.deny.result }}
           MSRV_RESULT: ${{ needs.msrv.result }}
+          PIN_CHECK_RESULT: ${{ needs.pin-check.result }}
         run: |
           if [[ "$FMT_RESULT" != "success" ]] || \
              [[ "$CLIPPY_RESULT" != "success" ]] || \
              [[ "$TEST_RESULT" != "success" ]] || \
              [[ "$DOC_RESULT" != "success" ]] || \
              [[ "$DENY_RESULT" != "success" ]] || \
-             [[ "$MSRV_RESULT" != "success" ]]; then
+             [[ "$MSRV_RESULT" != "success" ]] || \
+             [[ "$PIN_CHECK_RESULT" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,5 +16,6 @@ permissions:
 
 jobs:
   automerge:
-    uses: zircote/.github/.github/workflows/reusable-dependabot-automerge.yml@main
+    # yamllint disable-line rule:line-length
+    uses: zircote/.github/.github/workflows/reusable-dependabot-automerge.yml@e8f0dbde068cc0701e443e7b8d57ae9917de7da3  # main
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,10 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     environment: copilot
+    permissions:
+      contents: read
+      # OIDC for crates.io Trusted Publishing
+      id-token: write
     steps:
       - name: Checkout repository
         # yamllint disable-line rule:line-length
@@ -51,8 +55,18 @@ jobs:
       - name: Dry run publish
         run: cargo publish --dry-run --allow-dirty
 
+      # Trusted Publishing (OIDC): no long-lived registry token. Requires
+      # the one-time crates.io setup — crate Settings -> Trusted Publishing
+      # -> add GitHub repo zircote/rlm-rs, workflow publish.yml,
+      # environment copilot.
+      - name: Authenticate with crates.io
+        id: auth
+        if: startsWith(github.ref, 'refs/tags/v')
+        # yamllint disable-line rule:line-length
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe  # v1.0.4
+
       - name: Publish to crates.io
         if: startsWith(github.ref, 'refs/tags/v')
         run: cargo publish --token "$CARGO_REGISTRY_TOKEN"
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,13 @@
 ---
 name: Release
 
+# Attested delivery: build platform binaries, attach SLSA build provenance
+# to each, then fail-closed verify every attestation BEFORE the GitHub
+# Release is published. A tag publishes nothing unattested.
+#
+# Dry-run: `workflow_dispatch` from any branch exercises the full
+# build -> attest -> verify chain; the publish job is tag-gated and skipped.
+
 "on":
   push:
     tags:
@@ -8,38 +15,159 @@ name: Release
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  create-release:
-    name: Create Release
+  version:
+    name: Resolve Version
     runs-on: ubuntu-latest
-    environment: copilot
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
       - name: Checkout repository
         # yamllint disable-line rule:line-length
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-        with:
-          fetch-depth: 0
 
-      - name: Get version from tag
+      - name: Get version from tag or Cargo.toml
         id: get_version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          else
+            # Dry-run (workflow_dispatch): version from Cargo.toml, marked -dev
+            v=$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)
+            echo "version=${v}-dev" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build (${{ matrix.platform }})
+    needs: [version]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux-amd64
+            ext: ""
+          - os: ubuntu-24.04-arm
+            platform: linux-arm64
+            ext: ""
+          - os: macos-15-intel
+            platform: macos-amd64
+            ext: ""
+          - os: macos-latest
+            platform: macos-arm64
+            ext: ""
+          - os: windows-latest
+            platform: windows-amd64
+            ext: ".exe"
+    steps:
+      - name: Checkout repository
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Install Rust toolchain
+        # yamllint disable-line rule:line-length
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # master
+        with:
+          toolchain: stable
+
+      - name: Build release binary
+        run: cargo build --release --locked
+
+      - name: Stage named artifact
+        shell: bash
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          PLATFORM: ${{ matrix.platform }}
+          EXT: ${{ matrix.ext }}
+        run: |
+          mkdir -p dist
+          cp "target/release/rlm-cli${EXT}" \
+            "dist/rlm-cli-${VERSION}-${PLATFORM}${EXT}"
+
+      - name: Attest build provenance
+        # yamllint disable-line rule:line-length
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-path: dist/*
+
+      - name: Upload artifact
+        # yamllint disable-line rule:line-length
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          # yamllint disable-line rule:line-length
+          name: rlm-cli-${{ needs.version.outputs.version }}-${{ matrix.platform }}
+          path: dist/*
+          if-no-files-found: error
+
+  verify:
+    name: Verify Attestations
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      attestations: read
+    steps:
+      - name: Download all artifacts
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Fail-closed attestation verification
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(dist/*)
+          # All five platform binaries must be present — a partial set
+          # must never reach the release.
+          if [ "${#files[@]}" -ne 5 ]; then
+            echo "::error::expected 5 artifacts, found ${#files[@]}"
+            exit 1
+          fi
+          for f in "${files[@]}"; do
+            echo "Verifying ${f}"
+            gh attestation verify "$f" --repo "$GITHUB_REPOSITORY"
+          done
+
+  release:
+    name: Create Release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [version, verify]
+    runs-on: ubuntu-latest
+    environment: copilot
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v2.0.3
         with:
           tag_name: ${{ github.ref }}
-          name: Release ${{ steps.get_version.outputs.version }}
+          name: Release ${{ needs.version.outputs.version }}
           generate_release_notes: true
           draft: false
           prerelease: false
+          files: dist/*
         env:
           # Use PAT so release event propagates to
           # downstream workflows (homebrew)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,9 +109,73 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+  audit:
+    name: Cargo Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Install cargo-audit
+        # yamllint disable-line rule:line-length
+        uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154  # v2.81.8
+        with:
+          tool: cargo-audit
+
+      - name: Audit dependencies for known vulnerabilities
+        run: cargo audit
+
+  sbom:
+    name: SBOM (generate + attest)
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout repository
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Download all binaries
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate CycloneDX SBOM
+        # yamllint disable-line rule:line-length
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          # yamllint disable-line rule:line-length
+          output-file: rlm-cli-${{ needs.version.outputs.version }}-sbom.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest SBOM (binds every binary to the SBOM)
+        # yamllint disable-line rule:line-length
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e  # v4.1.0
+        with:
+          subject-path: dist/*
+          # yamllint disable-line rule:line-length
+          sbom-path: rlm-cli-${{ needs.version.outputs.version }}-sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        # yamllint disable-line rule:line-length
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: rlm-cli-${{ needs.version.outputs.version }}-sbom
+          path: rlm-cli-${{ needs.version.outputs.version }}-sbom.cdx.json
+          if-no-files-found: error
+
   verify:
     name: Verify Attestations
-    needs: [version, build]
+    needs: [version, build, sbom]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -131,21 +195,27 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
           files=(dist/*)
-          # Every platform binary must be present — a partial set
-          # must never reach the release.
-          if [ "${#files[@]}" -ne 4 ]; then
-            echo "::error::expected 4 artifacts, found ${#files[@]}"
+          # Every platform binary plus the SBOM must be present — a
+          # partial set must never reach the release.
+          if [ "${#files[@]}" -ne 5 ]; then
+            echo "::error::expected 5 artifacts, found ${#files[@]}"
             exit 1
           fi
           for f in "${files[@]}"; do
-            echo "Verifying ${f}"
+            case "$f" in
+              *-sbom.cdx.json) continue ;;
+            esac
+            echo "Verifying provenance: ${f}"
             gh attestation verify "$f" --repo "$GITHUB_REPOSITORY"
+            echo "Verifying SBOM attestation: ${f}"
+            gh attestation verify "$f" --repo "$GITHUB_REPOSITORY" \
+              --predicate-type https://cyclonedx.org/bom
           done
 
   release:
     name: Create Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [version, verify]
+    needs: [version, verify, audit]
     runs-on: ubuntu-latest
     environment: copilot
     permissions:
@@ -157,6 +227,13 @@ jobs:
         with:
           path: dist
           merge-multiple: true
+
+      - name: Generate checksums
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          cd dist
+          sha256sum -- * > "rlm-cli-${VERSION}-checksums.txt"
 
       - name: Create GitHub Release
         # yamllint disable-line rule:line-length

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,25 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+  test:
+    # Tags are not guaranteed to point at CI-green commits; the release
+    # publishes nothing untested.
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Install Rust toolchain
+        # yamllint disable-line rule:line-length
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # master
+        with:
+          toolchain: stable
+
+      - name: Run tests
+        run: cargo test --all-features --locked
+
   audit:
     name: Cargo Audit
     runs-on: ubuntu-latest
@@ -215,7 +234,7 @@ jobs:
   release:
     name: Create Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [version, verify, audit]
+    needs: [version, verify, audit, test]
     runs-on: ubuntu-latest
     environment: copilot
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,9 @@ jobs:
           - os: ubuntu-24.04-arm
             platform: linux-arm64
             ext: ""
-          - os: macos-15-intel
-            platform: macos-amd64
-            ext: ""
+          # macos-amd64 is intentionally absent: ort (onnxruntime, via the
+          # default fastembed feature) ships no prebuilt binaries for
+          # x86_64-apple-darwin, so Intel macOS cannot build this crate.
           - os: macos-latest
             platform: macos-arm64
             ext: ""
@@ -131,10 +131,10 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
           files=(dist/*)
-          # All five platform binaries must be present — a partial set
+          # Every platform binary must be present — a partial set
           # must never reach the release.
-          if [ "${#files[@]}" -ne 5 ]; then
-            echo "::error::expected 5 artifacts, found ${#files[@]}"
+          if [ "${#files[@]}" -ne 4 ]; then
+            echo "::error::expected 4 artifacts, found ${#files[@]}"
             exit 1
           fi
           for f in "${files[@]}"; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   via `actions/attest-sbom` and verified fail-closed alongside provenance
 - **Release**: `cargo audit` gate — a release publishes nothing if any
   dependency carries a known vulnerability
+- **Release**: test gate — tags are not guaranteed to point at CI-green
+  commits, so the release workflow runs the full test suite and publishes
+  nothing untested
 - **Release**: `rlm-cli-{version}-checksums.txt` asset with SHA-256 digests
   of all release artifacts
 - **Release**: crates.io publishing now uses Trusted Publishing (OIDC) via

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Release**: Attested delivery — releases now publish platform binaries
-  (`rlm-cli-{version}-{platform}` for linux-amd64, linux-arm64, macos-amd64,
-  macos-arm64, windows-amd64.exe), each carrying SLSA build provenance via
+  (`rlm-cli-{version}-{platform}` for linux-amd64, linux-arm64, macos-arm64,
+  windows-amd64.exe), each carrying SLSA build provenance via
   `actions/attest-build-provenance`
+  - macos-amd64 is not published: ort (onnxruntime, via the default
+    fastembed feature) provides no prebuilt binaries for
+    `x86_64-apple-darwin`
   - Release publication is gated on fail-closed attestation verification —
     a tag publishes nothing unattested
   - `workflow_dispatch` dry-run exercises the build → attest → verify chain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Release**: Attested delivery — releases now publish platform binaries
+  (`rlm-cli-{version}-{platform}` for linux-amd64, linux-arm64, macos-amd64,
+  macos-arm64, windows-amd64.exe), each carrying SLSA build provenance via
+  `actions/attest-build-provenance`
+  - Release publication is gated on fail-closed attestation verification —
+    a tag publishes nothing unattested
+  - `workflow_dispatch` dry-run exercises the build → attest → verify chain
+    without cutting a release
+- **Security**: `SECURITY.md` with vulnerability reporting policy and
+  release-artifact verification instructions (`gh attestation verify`)
+
+### Security
+
+- **CI**: `pin-check` job (central `zircote/.github` reusable workflow)
+  asserts every GitHub Actions `uses:` reference is pinned to a full
+  40-character commit SHA
+- **CI**: pinned the two remaining mutable action refs
+  (`github/gh-aw/actions/setup@v0.77.5`,
+  `reusable-dependabot-automerge.yml@main`) to commit SHAs
+
 ### Changed
 
 - **Build**: Bump MSRV to 1.95 — libsqlite3-sys 0.38.1 (via the rusqlite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     without cutting a release
 - **Security**: `SECURITY.md` with vulnerability reporting policy and
   release-artifact verification instructions (`gh attestation verify`)
+- **Release**: CycloneDX SBOM per release (Syft), attested to every binary
+  via `actions/attest-sbom` and verified fail-closed alongside provenance
+- **Release**: `cargo audit` gate — a release publishes nothing if any
+  dependency carries a known vulnerability
+- **Release**: `rlm-cli-{version}-checksums.txt` asset with SHA-256 digests
+  of all release artifacts
+- **Release**: crates.io publishing now uses Trusted Publishing (OIDC) via
+  `rust-lang/crates-io-auth-action` instead of a long-lived registry token
+  (requires one-time Trusted Publishing setup on crates.io before the next
+  release)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI**: `pin-check` job (central `zircote/.github` reusable workflow)
   asserts every GitHub Actions `uses:` reference is pinned to a full
   40-character commit SHA
-- **CI**: pinned the two remaining mutable action refs
-  (`github/gh-aw/actions/setup@v0.77.5`,
-  `reusable-dependabot-automerge.yml@main`) to commit SHAs
+- **CI**: pinned the remaining mutable workflow ref
+  (`reusable-dependabot-automerge.yml@main`) to a commit SHA
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Dependencies**: update quinn-proto 0.11.13 → 0.11.14 in the lockfile
+  (RUSTSEC-2026-0037); the entry was an unreachable phantom resolution — no
+  shipped binary included the vulnerable code — but the audit gate flags it
+- **Supply chain**: align `deny.toml` `[graph] targets` with the release
+  matrix (adds `aarch64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`) so
+  cargo-deny analyzes every shipped platform's dependency graph
 - **CI**: `pin-check` job (central `zircote/.github` reusable workflow)
   asserts every GitHub Actions `uses:` reference is pinned to a full
   40-character commit SHA

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # rlm-rs
 
 [![CI](https://github.com/zircote/rlm-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/zircote/rlm-rs/actions/workflows/ci.yml)
+[![Release](https://github.com/zircote/rlm-rs/actions/workflows/release.yml/badge.svg)](https://github.com/zircote/rlm-rs/actions/workflows/release.yml)
+[![SLSA Build Provenance](https://img.shields.io/badge/SLSA-build_provenance-FF6740)](https://github.com/zircote/rlm-rs/attestations)
+[![Attested Releases](https://img.shields.io/badge/releases-attested_%26_verified-2ea44f?logo=github&logoColor=white)](https://github.com/zircote/rlm-rs/blob/main/SECURITY.md#verifying-release-artifacts)
+[![Actions Pinned](https://img.shields.io/badge/actions-SHA--pinned-blue)](https://github.com/zircote/rlm-rs/blob/main/.github/workflows/ci.yml)
 [![Rust Version](https://img.shields.io/badge/rust-1.95%2B-dea584?logo=rust&logoColor=white)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
@@ -51,6 +55,18 @@ git clone https://github.com/zircote/rlm-rs.git
 cd rlm-rs
 make install
 ```
+
+### Verify a Release Binary
+
+Every release binary carries [SLSA build provenance](https://slsa.dev/spec/v1.0/provenance),
+and releases only publish after fail-closed attestation verification. To verify a
+download yourself:
+
+```bash
+gh attestation verify rlm-cli-<version>-<platform> --repo zircote/rlm-rs
+```
+
+See [SECURITY.md](SECURITY.md#verifying-release-artifacts) for details.
 
 ## Quick Start
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,3 +32,21 @@ A successful verification prints `✓ Verification succeeded!` and confirms
 the binary is byte-identical to what GitHub Actions built from this
 repository. Verification fails closed if the file was modified, rebuilt
 elsewhere, or attested by any other repository or workflow.
+
+### SBOM
+
+Each release ships a CycloneDX SBOM (`rlm-cli-<version>-sbom.cdx.json`)
+generated with Syft, and every binary carries an SBOM attestation binding
+it to that SBOM. To verify:
+
+```sh
+gh attestation verify rlm-cli-<version>-<platform> --repo zircote/rlm-rs \
+  --predicate-type https://cyclonedx.org/bom
+```
+
+### Checksums
+
+`rlm-cli-<version>-checksums.txt` lists SHA-256 digests of every release
+asset for quick integrity checks (`sha256sum -c`). Checksums are a
+convenience; the attestations above are the authoritative, fail-closed
+verification path.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Report vulnerabilities privately via
+[GitHub Security Advisories](https://github.com/zircote/rlm-rs/security/advisories/new).
+Do not open a public issue for security reports.
+
+## Verifying Release Artifacts
+
+Every release binary is built on GitHub Actions and carries
+[SLSA build provenance](https://slsa.dev/spec/v1.0/provenance) attested with
+`actions/attest-build-provenance`. The release pipeline verifies every
+attestation fail-closed before the GitHub Release is published — a tag
+publishes nothing unattested.
+
+To verify a downloaded artifact yourself (requires the
+[`gh` CLI](https://cli.github.com/), authenticated):
+
+```sh
+gh release download v<version> --repo zircote/rlm-rs
+gh attestation verify rlm-cli-<version>-<platform> --repo zircote/rlm-rs
+```
+
+For example:
+
+```sh
+gh attestation verify rlm-cli-1.2.5-linux-amd64 --repo zircote/rlm-rs
+```
+
+A successful verification prints `✓ Verification succeeded!` and confirms
+the binary is byte-identical to what GitHub Actions built from this
+repository. Verification fails closed if the file was modified, rebuilt
+elsewhere, or attested by any other repository or workflow.

--- a/deny.toml
+++ b/deny.toml
@@ -2,10 +2,14 @@
 # https://embarkstudios.github.io/cargo-deny/
 
 [graph]
+# Keep in sync with the release matrix in .github/workflows/release.yml
+# (plus x86_64-apple-darwin for source builds on Intel macs).
 targets = [
     "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
     "x86_64-apple-darwin",
     "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
 ]
 
 #==============================================================================


### PR DESCRIPTION
## Summary

Onboards rlm-rs to the attested delivery architecture (Mode A — consumer of the existing `zircote/.github` central workflows, pinned at `e8f0dbde068cc0701e443e7b8d57ae9917de7da3`).

This repo is **binaries-only** (no container build), so the wiring is per-artifact SLSA provenance rather than the image signing chain. The release previously published **no artifacts at all** — only auto-generated notes.

### Release pipeline (`release.yml`)

`version → build (4-platform matrix) → verify (fail-closed) → release (tag-gated)`

- Builds `rlm-cli-{version}-{platform}` for linux-amd64, linux-arm64, macos-arm64, windows-amd64.exe — all on native runners, default features (matches `cargo install` / Homebrew)
- macos-amd64 is deliberately absent: ort (onnxruntime, via the default fastembed feature) ships no prebuilt binaries for `x86_64-apple-darwin` — Intel macOS cannot build this crate's default features at all (the first dry-run proved it)
- Each binary gets SLSA build provenance via `actions/attest-build-provenance`
- **Fail-closed verify gate**: all 4 artifacts must be present and every `gh attestation verify` must pass before the publish job runs — a tag publishes nothing unattested
- **Dry-run**: `workflow_dispatch` from any branch exercises build → attest → verify; publish is tag-gated (`startsWith(github.ref, 'refs/tags/')`)
- Release job keeps the `copilot` environment and the `HOMEBREW_TAP_TOKEN` PAT (release-event propagation to the homebrew workflow)

### Supply-chain pinning

- New `pin-check` job in CI calling the central `pin-check.yml` (pinned by full SHA), wired into `all-checks-pass`
- Pinned the last two mutable refs: `github/gh-aw/actions/setup@v0.77.5` → `f990bbb…`, `reusable-dependabot-automerge.yml@main` → `e8f0dbd…`
- Entire `.github` tree now passes the pin-check scan

### SBOM, audit gate, checksums, trusted publishing

- **SBOM**: dedicated `sbom` job generates one CycloneDX SBOM per release (Syft), attests it to every binary (`actions/attest-sbom`), ships it as a release asset; the verify gate now asserts the SBOM attestation per binary, fail-closed
- **Audit gate**: `cargo audit` job — release publishes nothing if any dependency carries a known vulnerability
- **Checksums**: `rlm-cli-{version}-checksums.txt` asset (SHA-256 of all artifacts)
- **Test gate**: tags aren't guaranteed to point at CI-green commits — the release workflow runs the full test suite and publishes nothing untested
- **crates.io Trusted Publishing**: `publish.yml` now authenticates via OIDC (`rust-lang/crates-io-auth-action`) instead of `CARGO_REGISTRY_TOKEN`. ⚠️ **Requires one-time setup before the next release**: crates.io → rlm-cli → Settings → Trusted Publishing → add repo `zircote/rlm-rs`, workflow `publish.yml`, environment `copilot`. The old token can then be revoked.

### Findings the new gates surfaced (fixed here)

- **quinn-proto 0.11.13 / RUSTSEC-2026-0037** (high, DoS): caught by the new audit gate on the first dry-run. The lock entry was an unreachable phantom resolution — `cargo tree` shows no path under any feature/target combination, so no shipped binary contained the vulnerable code — but it's now updated to 0.11.14.
- **`deny.toml` target blindness**: `[graph] targets` was missing `aarch64-unknown-linux-gnu` and `x86_64-pc-windows-msvc`, so cargo-deny never analyzed target-specific deps for two shipped platforms. Now synced with the release matrix.

### Repo settings changed alongside (not in the diff)

- Enabled **vulnerability alerts** and **Dependabot security updates** (were disabled; secret scanning + push protection were already on).

### Docs

- `SECURITY.md` (new): vulnerability reporting + "Verifying Release Artifacts" (`gh attestation verify <file> --repo zircote/rlm-rs` — no `--signer-workflow`, since artifacts are attested by this repo's own workflow, not the central signer)
- CHANGELOG entry under Unreleased

## Validation performed

- `actionlint` clean on all touched workflows
- yamllint: zero errors on changed lines (pre-existing warnings in `ci.yml` left untouched)
- Replicated the central pin-check scan logic over the full `.github` tree: ALL PINNED

## Post-merge steps (not automatable in a PR)

1. **Dry-run the chain**: `gh workflow run release.yml --ref main` — build → attest → verify must go green (publish skips, no tag)
2. **Make pin-check required** once green on main (context name is `pin-check / pin-check`):

   ```sh
   gh api -X PATCH repos/zircote/rlm-rs/branches/main/protection/required_status_checks \
     -f strict=true -f "contexts[]=All Checks Pass" -f "contexts[]=pin-check / pin-check"
   ```

   (branch protection currently has **zero** required status checks)
3. **Independent acceptance test** after the first real tag: download a binary from the release on a workstation and run `gh attestation verify <file> --repo zircote/rlm-rs` — in-pipeline success is not the acceptance test
4. Merge #234 (MSRV 1.95 fix) first — the MSRV check fails on every branch until it lands; this PR goes green after an update-branch

## Out of scope

- No deploy target → promotion (`promote.yml`/`promote-prod.yml`), DORA emission, and admission enforcement are explicitly out of scope (Phase 0 finding)
- `publish.yml` (crates.io) untouched — source publication, not artifact delivery; crates.io trusted publishing is a possible follow-up

## Merge-order note

This PR and #232 both touch `agentics-maintenance.yml` (this PR pins a ref in the old generated file; #232 regenerates it for v0.79.6 with all refs pinned). Whichever merges second needs a trivial rebase — the regenerated file wins.

## Related

- #232 (gh-aw v0.79.6 upgrade) — independent branch; its generated `copilot-setup-steps.yml` was SHA-pinned there so it passes pin-check once both merge

- #234 (MSRV 1.95 fix) — must merge first; unblocks the MSRV check on this and the Dependabot PRs
