### PR TITLE
fix: bump MSRV to 1.95 for libsqlite3-sys 0.38.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,9 +155,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-msrv-1.95-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-msrv-
+            ${{ runner.os }}-cargo-msrv-1.95-
 
       - name: Check MSRV
         run: cargo check --all-features --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: "1.88"
+          toolchain: "1.95"
 
       - name: Cache cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -160,7 +160,7 @@ jobs:
             ${{ runner.os }}-cargo-msrv-
 
       - name: Check MSRV
-        run: cargo check --all-features
+        run: cargo check --all-features --locked
 
   coverage:
     name: Coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Build**: Bump MSRV to 1.95 — libsqlite3-sys 0.38.1 (via the rusqlite
+  0.40.1 bump) uses `cfg_select!`, stabilized in Rust 1.95; the MSRV CI job
+  now also passes `--locked` so it checks the dependency versions that
+  actually ship
+
 - **Documentation**: Enhanced troubleshooting guide with usearch version pinning details
   - Documented the `<2.25` version constraint; usearch v2.24.x is supported since rlm-cli v1.2.4
   - Added troubleshooting section for usearch version issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please be respectful and constructive in all interactions. We welcome contributo
 
 ### Prerequisites
 
-- **Rust 1.88+** (2024 edition)
+- **Rust 1.95+** (2024 edition)
 - **cargo-deny** for supply chain security checks
 
 ```bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rlm-cli"
 version = "1.2.4"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.95"
 description = "Recursive Language Model (RLM) REPL for Claude Code - handles long-context tasks via chunking and recursive sub-LLM calls"
 license = "MIT"
 authors = ["zircote"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rlm-rs
 
 [![CI](https://github.com/zircote/rlm-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/zircote/rlm-rs/actions/workflows/ci.yml)
-[![Rust Version](https://img.shields.io/badge/rust-1.88%2B-dea584?logo=rust&logoColor=white)](https://www.rust-lang.org/)
+[![Rust Version](https://img.shields.io/badge/rust-1.95%2B-dea584?logo=rust&logoColor=white)](https://www.rust-lang.org/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 Recursive Language Model (RLM) CLI for Claude Code - handles long-context tasks via chunking and recursive sub-LLM calls.
@@ -145,7 +145,7 @@ rlm-cli is designed to work with the [rlm-rs Claude Code plugin](https://github.
 
 ### Prerequisites
 
-- Rust 1.88+ (2024 edition)
+- Rust 1.95+ (2024 edition)
 - [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) for supply chain security
 
 ### Build
@@ -184,7 +184,7 @@ tests/
 
 ## MSRV Policy
 
-The Minimum Supported Rust Version (MSRV) is **1.88**.
+The Minimum Supported Rust Version (MSRV) is **1.95**.
 
 ## License
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -29,7 +29,7 @@ allow-unwrap-in-tests = true
 allow-print-in-tests = true
 
 # MSRV for lint behavior
-msrv = "1.88"
+msrv = "1.95"
 
 # Type complexity threshold
 type-complexity-threshold = 250

--- a/docs/adr/002-use-rust-as-implementation-language.md
+++ b/docs/adr/002-use-rust-as-implementation-language.md
@@ -206,7 +206,7 @@ Mitigations:
 | Finding | Files | Lines | Assessment |
 |---------|-------|-------|------------|
 | Rust edition 2024 configured | `Cargo.toml` | L3 | compliant |
-| MSRV 1.88 specified | `Cargo.toml` | L7 | compliant |
+| MSRV 1.95 specified | `Cargo.toml` | L7 | compliant |
 | Strict clippy lints enabled | `Cargo.toml` | L89-L120 | compliant |
 | No unsafe code blocks | all | - | compliant |
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,7 +46,7 @@ Three options:
 ### What are the system requirements?
 
 - **OS**: macOS, Linux, or Windows
-- **Rust**: 1.88+ (if building from source)
+- **Rust**: 1.95+ (if building from source)
 - **Disk**: ~50MB for binaries + embeddings model
 - **Memory**: 512MB minimum, 2GB+ recommended for large files
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -156,7 +156,7 @@ cargo build --release --features full-search
 
 ````dockerfile
 # Dockerfile example - minimal size
-FROM rust:1.88-slim AS builder
+FROM rust:1.95-slim AS builder
 WORKDIR /app
 COPY . .
 RUN cargo build --release --no-default-features

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ Think of it as a "smart pagination system" that lets AI assistants navigate huge
 
 ## Prerequisites
 
-- **Rust 1.88+** (or use pre-built binaries)
+- **Rust 1.95+** (or use pre-built binaries)
 - **macOS, Linux, or Windows**
 
 ## Installation

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,7 +31,7 @@ error: failed to compile `rlm-cli` v1.2.4
 ````bash
 # Check version
 rustc --version
-# Required: 1.88+
+# Required: 1.95+
 
 # Update Rust
 rustup update stable

--- a/site/src/content/docs/design-decisions/adr-002.mdx
+++ b/site/src/content/docs/design-decisions/adr-002.mdx
@@ -189,7 +189,7 @@ Mitigations:
 | Finding | Files | Lines | Assessment |
 |---------|-------|-------|------------|
 | Rust edition 2024 configured | `Cargo.toml` | L3 | compliant |
-| MSRV 1.88 specified | `Cargo.toml` | L7 | compliant |
+| MSRV 1.95 specified | `Cargo.toml` | L7 | compliant |
 | Strict clippy lints enabled | `Cargo.toml` | L89-L120 | compliant |
 | No unsafe code blocks | all | - | compliant |
 

--- a/site/src/content/docs/getting-started/features.mdx
+++ b/site/src/content/docs/getting-started/features.mdx
@@ -159,7 +159,7 @@ cargo build --release --features full-search
 
 ````dockerfile
 # Dockerfile example - minimal size
-FROM rust:1.88-slim AS builder
+FROM rust:1.95-slim AS builder
 WORKDIR /app
 COPY . .
 RUN cargo build --release --no-default-features

--- a/site/src/content/docs/troubleshooting/troubleshooting.mdx
+++ b/site/src/content/docs/troubleshooting/troubleshooting.mdx
@@ -34,7 +34,7 @@ error: failed to compile `rlm-cli` v1.2.4
 ````bash
 # Check version
 rustc --version
-# Required: 1.88+
+# Required: 1.95+
 
 # Update Rust
 rustup update stable


### PR DESCRIPTION
## Summary

**Every open PR is currently failing the MSRV check** — and so would main. Root cause: the rusqlite 0.40.1 bump (#228) pulled in libsqlite3-sys 0.38.1, whose build script uses `cfg_select!` — a macro stabilized in **Rust 1.95.0** (2026-04-16). The MSRV job still checks with 1.88.

## Changes

- `Cargo.toml` `rust-version` 1.88 → 1.95
- MSRV CI job toolchain 1.88 → 1.95, and now passes `--locked` so the check resolves the dependency versions that actually ship (the silent re-resolution is how this class of break slips in)
- `clippy.toml` `msrv`, README badge/prereqs/MSRV policy, CONTRIBUTING updated to match
- CHANGELOG entry

## Why a standalone PR

This unblocks #230, #231, #232 (Dependabot automerge is stuck on the red MSRV check) without waiting on review of the larger #233. Merge this first; the other PRs go green after an update-branch.

## Validation

- `actionlint` clean
- Root cause confirmed from the failing job log (`cannot find macro \`cfg_select\` in this scope` in libsqlite3-sys-0.38.1/build.rs) and Rust 1.95.0 release notes