### PR TITLE
ci: attest the published crates.io .crate archive

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,10 @@ jobs:
     environment: copilot
     permissions:
       contents: read
-      # OIDC for crates.io Trusted Publishing
+      # OIDC for crates.io Trusted Publishing and .crate attestation signing
       id-token: write
+      # Provenance attestation for the published .crate
+      attestations: write
     steps:
       - name: Checkout repository
         # yamllint disable-line rule:line-length
@@ -70,3 +72,43 @@ jobs:
         run: cargo publish --token "$CARGO_REGISTRY_TOKEN"
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      # Attest the bytes the registry actually serves, not a local rebuild:
+      # download the published .crate, assert it matches what cargo packaged
+      # locally (cargo packaging is deterministic for a given commit — a
+      # mismatch means something is wrong and must fail loudly), then attach
+      # SLSA provenance to it.
+      - name: Download published crate from registry
+        id: crate
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          CRATE="rlm-cli-${VERSION}.crate"
+          URL="https://static.crates.io/crates/rlm-cli/${CRATE}"
+          for attempt in 1 2 3 4 5 6; do
+            if curl -fsSL -o "${CRATE}" "$URL"; then
+              break
+            fi
+            echo "crate not yet on CDN (attempt ${attempt}); retrying"
+            sleep 10
+          done
+          test -s "${CRATE}"
+          LOCAL="target/package/${CRATE}"
+          if [ ! -f "$LOCAL" ]; then
+            echo "::error::locally packaged crate missing: ${LOCAL}"
+            exit 1
+          fi
+          sha_remote=$(sha256sum "${CRATE}" | cut -d' ' -f1)
+          sha_local=$(sha256sum "$LOCAL" | cut -d' ' -f1)
+          if [ "$sha_remote" != "$sha_local" ]; then
+            echo "::error::registry crate bytes differ from local package"
+            exit 1
+          fi
+          echo "crate-path=${CRATE}" >> "$GITHUB_OUTPUT"
+
+      - name: Attest crate provenance
+        if: startsWith(github.ref, 'refs/tags/v')
+        # yamllint disable-line rule:line-length
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-path: ${{ steps.crate.outputs.crate-path }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Release**: the published crates.io `.crate` archive now carries SLSA
+  build provenance — the workflow downloads the registry-served bytes,
+  asserts they match the locally packaged crate, and attests them;
+  verification instructions added to `SECURITY.md`
+
 ## [1.3.0] - 2026-06-12
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,21 @@ gh attestation verify rlm-cli-<version>-<platform> --repo zircote/rlm-rs \
   --predicate-type https://cyclonedx.org/bom
 ```
 
+### crates.io source package
+
+The published `.crate` source archive also carries SLSA build provenance,
+attested against the exact bytes the registry serves:
+
+```sh
+curl -fsSLO https://static.crates.io/crates/rlm-cli/rlm-cli-<version>.crate
+gh attestation verify rlm-cli-<version>.crate --repo zircote/rlm-rs
+```
+
+Note that binaries you compile yourself from the crate are not
+byte-identical to the attested release binaries — Rust builds are not
+reproducible by default. The attestation covers the source archive;
+crates.io's checksum chain and Cargo.lock pin it from there.
+
 ### Checksums
 
 `rlm-cli-<version>-checksums.txt` lists SHA-256 digests of every release


### PR DESCRIPTION
## Summary

Extends provenance coverage to the crates.io channel. After `cargo publish` (tag runs only), the workflow:

1. Downloads the published `.crate` from `static.crates.io` (with retry for CDN propagation)
2. Asserts the registry bytes are sha256-identical to the locally packaged crate — cargo packaging is deterministic per commit, so a mismatch is a loud failure, and no attestation is produced for unverified bytes
3. Attests the **registry-served bytes** with `actions/attest-build-provenance`

Consumers verify with:

```sh
curl -fsSLO https://static.crates.io/crates/rlm-cli/rlm-cli-<version>.crate
gh attestation verify rlm-cli-<version>.crate --repo zircote/rlm-rs
```

SECURITY.md gains a "crates.io source package" section (including the honest caveat that self-compiled binaries are not byte-identical to the attested release binaries); CHANGELOG entry under Unreleased.

## Validation

- `actionlint` clean
- Attestation steps are tag-gated (`startsWith(github.ref, 'refs/tags/v')`) — dispatch dry-runs skip them
- Permissions: added `attestations: write` (job already had `id-token: write` for Trusted Publishing)