### PR TITLE
fix: follow-up review fixes for crate attestation (#249)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,14 +85,19 @@ jobs:
           VERSION="${GITHUB_REF#refs/tags/v}"
           CRATE="rlm-cli-${VERSION}.crate"
           URL="https://static.crates.io/crates/rlm-cli/${CRATE}"
+          downloaded=0
           for attempt in 1 2 3 4 5 6; do
             if curl -fsSL -o "${CRATE}" "$URL"; then
+              downloaded=1
               break
             fi
             echo "crate not yet on CDN (attempt ${attempt}); retrying"
             sleep 10
           done
-          test -s "${CRATE}"
+          if [ "$downloaded" -ne 1 ] || [ ! -s "${CRATE}" ]; then
+            echo "::error::failed to download ${URL} after 6 attempts"
+            exit 1
+          fi
           LOCAL="target/package/${CRATE}"
           if [ ! -f "$LOCAL" ]; then
             echo "::error::locally packaged crate missing: ${LOCAL}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,7 +44,7 @@ gh attestation verify rlm-cli-<version>-<platform> --repo zircote/rlm-rs \
   --predicate-type https://cyclonedx.org/bom
 ```
 
-### crates.io source package
+### crates.io Source Package
 
 The published `.crate` source archive also carries SLSA build provenance,
 attested against the exact bytes the registry serves:


### PR DESCRIPTION
Two Copilot review comments on #249 arrived as it merged — applied here:

- Title-case the SECURITY.md "crates.io Source Package" heading (consistency with "### SBOM" / "### Checksums")
- The registry-download retry loop now emits a clear `::error::` with the URL and attempt count when the download never succeeds, instead of a bare `test -s` failure

`actionlint` clean.