### PR TITLE
fix: trigger homebrew formula update via workflow_run

### DIFF
--- a/.github/workflows/package-homebrew.yml
+++ b/.github/workflows/package-homebrew.yml
@@ -2,6 +2,12 @@
 name: Homebrew Package
 
 "on":
+  # workflow_run is the reliable trigger: releases are authored by
+  # github-actions[bot] (HOMEBREW_TAP_TOKEN is scoped to the tap repo
+  # only), and bot-authored release events do not trigger workflows.
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
   release:
     types: [published]
   workflow_dispatch:
@@ -22,6 +28,13 @@ jobs:
     name: Update Homebrew Formula
     runs-on: macos-latest
     environment: copilot
+    # workflow_run fires for every Release completion, including branch
+    # dry-runs — only proceed for successful tag runs (head_branch is the
+    # tag name for tag-triggered runs).
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
 
     steps:
       - name: Checkout homebrew tap
@@ -37,12 +50,15 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RUN_TAG: ${{ github.event.workflow_run.head_branch }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
           REPO: ${{ github.repository }}
         run: |
           if [ "$EVENT_NAME" = "release" ]; then
             VERSION="$RELEASE_TAG"
             VERSION="${VERSION#v}"
+          elif [ "$EVENT_NAME" = "workflow_run" ]; then
+            VERSION="${RUN_TAG#v}"
           else
             VERSION="$INPUT_VERSION"
           fi
@@ -104,8 +120,14 @@ jobs:
             "github-actions[bot]@users.noreply.github.com"
 
           git add Formula/rlm-cli.rb
-          git commit -m "rlm-cli: update to ${VERSION}"
-          git push
+          # Idempotent: with both workflow_run and release triggers wired,
+          # a second firing for the same version must be a no-op.
+          if git diff --staged --quiet; then
+            echo "Formula already up to date for ${VERSION}; nothing to push"
+          else
+            git commit -m "rlm-cli: update to ${VERSION}"
+            git push
+          fi
 
       - name: Show formula (dry run)
         if: github.event.inputs.dry_run == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release**: Homebrew formula updates now trigger via `workflow_run` on
+  the Release workflow — releases are authored by `github-actions[bot]`
+  (the tap token is scoped to the tap repo only), and bot-authored release
+  events never trigger workflows, so the formula silently stopped updating;
+  the formula commit is also idempotent now that two triggers are wired
+
 ### Added
 
 - **Release**: the published crates.io `.crate` archive now carries SLSA


### PR DESCRIPTION
## Summary

v1.3.0's Homebrew update never fired automatically: `action-gh-release` creates releases with the default token (the `HOMEBREW_TAP_TOKEN` PAT is fine-grained and scoped to `homebrew-tap` only, so it can't author releases on this repo), and **bot-authored release events never trigger workflows**. The formula needed a manual dispatch.

## Fix

- New primary trigger: `workflow_run` on the **Release** workflow — fires regardless of release authorship
- Job guard: only successful runs whose `head_branch` is a `v`-tag proceed (Release also runs as branch dry-runs via `workflow_dispatch`; those are ignored — and a dispatch of Release against a tag correctly counts as a release)
- Version derived from `workflow_run.head_branch` (the tag name on tag-triggered runs)
- The `release: published` trigger stays as belt-and-braces for any future PAT/UI-authored release; the formula commit is now **idempotent** so dual firing for one version is a no-op instead of a `git commit` failure
- `workflow_dispatch` manual path unchanged

## Validation

- `actionlint` + yamllint clean
- v1.3.0's formula was already pushed via manual dispatch — next tag exercises this path end-to-end