### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-06-12
+
 ### Fixed
 
 - **Release**: Homebrew formula updates now trigger via `workflow_run` on
@@ -271,7 +273,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Variable storage (context and global)
 - Export functionality
 
-[Unreleased]: https://github.com/zircote/rlm-rs/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/zircote/rlm-rs/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/zircote/rlm-rs/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/zircote/rlm-rs/compare/v1.2.4...v1.3.0
 [1.2.4]: https://github.com/zircote/rlm-rs/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/zircote/rlm-rs/compare/v1.2.2...v1.2.3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ abstract: >-
   tasks via chunking and recursive sub-LLM calls. Implements hybrid semantic
   and BM25 search with Reciprocal Rank Fusion, code-aware chunking, and
   pass-by-reference chunk retrieval for efficient subagent processing.
-version: 1.3.0
+version: 1.3.1
 date-released: 2026-06-12
 license: MIT
 url: "https://github.com/zircote/rlm-rs"
@@ -33,7 +33,7 @@ preferred-citation:
   abstract: >-
     Recursive Language Model (RLM) CLI for Claude Code - handles long-context
     tasks via chunking and recursive sub-LLM calls.
-  version: 1.3.0
+  version: 1.3.1
   date-released: 2026-06-12
   license: MIT
   url: "https://github.com/zircote/rlm-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "rlm-cli"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlm-cli"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2024"
 rust-version = "1.95"
 description = "Recursive Language Model (RLM) REPL for Claude Code - handles long-context tasks via chunking and recursive sub-LLM calls"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ gh attestation verify rlm-cli-<version>-<platform> --repo zircote/rlm-rs
 For example:
 
 ```sh
-gh attestation verify rlm-cli-1.3.0-linux-amd64 --repo zircote/rlm-rs
+gh attestation verify rlm-cli-1.3.1-linux-amd64 --repo zircote/rlm-rs
 ```
 
 A successful verification prints `✓ Verification succeeded!` and confirms


### PR DESCRIPTION
## Release v1.3.1

Release-pipeline patch — no source changes since 1.3.0. Contents: Homebrew `workflow_run` trigger fix (#251) and crates.io `.crate` provenance attestation (#249/#250).

This release doubles as the end-to-end test of the two never-exercised paths:
1. `.crate` attestation (download registry bytes → sha256 match vs local package → attest)
2. Homebrew formula auto-trigger via `workflow_run` (no manual dispatch this time — that's the test)

### After merge
Tag `v1.3.1`; verify chain: Release (binaries/SBOM/verify) → Publish (TP + crate attestation) → Homebrew fires automatically.