### PR TITLE
fix(security): remediate code-scanning alerts in docs-site generators

### DIFF
--- a/site/scripts/generate-docs-pages.mjs
+++ b/site/scripts/generate-docs-pages.mjs
@@ -138,8 +138,15 @@ export function generateDocsPages(outputBase) {
     const extractedTitle = extractTitle(stripped);
     const frontmatter = buildFrontmatter(page, extractedTitle);
 
-    // Strip HTML comments which are invalid in MDX
-    let body = stripped.replace(/<!--[\s\S]*?-->/g, "");
+    // Strip HTML comments which are invalid in MDX.
+    // Re-apply until stable so overlapping matches can't leave a residual <!--;
+    // unterminated comments strip to end of input, matching HTML semantics
+    let body = stripped;
+    let prevBody;
+    do {
+      prevBody = body;
+      body = body.replace(/<!--[\s\S]*?(?:-->|$)/g, "");
+    } while (body !== prevBody);
     // Strip image references to non-existent local files
     body = body.replace(/!\[([^\]]*)\]\((?!https?:\/\/)([^)]+)\)\n*/g, "");
     // Rewrite markdown links to Starlight URLs

--- a/site/scripts/generate-reference-pages.mjs
+++ b/site/scripts/generate-reference-pages.mjs
@@ -116,9 +116,15 @@ function extractSection(content, heading) {
 
   // Strip trailing HR separators (with possible blank lines) and HTML comments
   let cleaned = body.trim();
-  cleaned = cleaned.replace(/(\n\s*)*---\s*$/, "").trim();
-  cleaned = cleaned.replace(/<!--[\s\S]*?-->/g, "").trim();
-  return cleaned;
+  cleaned = cleaned.replace(/\s*---\s*$/, "").trim();
+  // Re-apply until stable so overlapping matches can't leave a residual <!--;
+  // unterminated comments strip to end of input, matching HTML semantics
+  let prev;
+  do {
+    prev = cleaned;
+    cleaned = cleaned.replace(/<!--[\s\S]*?(?:-->|$)/g, "");
+  } while (cleaned !== prev);
+  return cleaned.trim();
 }
 
 /**


### PR DESCRIPTION
## Summary

Resolves all 3 open high-severity CodeQL code-scanning alerts, all in the docs-site generator scripts.

| Alert | Rule | Location | Fix |
|---|---|---|---|
| #1 | `js/redos` | `site/scripts/generate-reference-pages.mjs` | Replaced `/(\n\s*)*---\s*$/` (nested quantifier over `\s`, exponential backtracking) with the linear, behavior-equivalent `/\s*---\s*$/` |
| #2 | `js/incomplete-multi-character-sanitization` | `site/scripts/generate-reference-pages.mjs` | HTML-comment stripping now loops to a fixpoint with an `(?:-->\|$)` terminator |
| #3 | `js/incomplete-multi-character-sanitization` | `site/scripts/generate-docs-pages.mjs` | Same fixpoint strip |

A plain fixpoint loop on `/<!--[\s\S]*?-->/g` is **not** sufficient: `<!<!-- -->--inner` stabilizes at `<!--inner`. Adding `(?:-->|$)` means any surviving `<!--` always matches, so loop termination proves no `<!--` remains; unterminated comments strip to end of input, matching HTML semantics.

## Verification

- One-shot node assertions: adversarial residue case (`<!<!-- -->--inner<!-- x -->` → `""`), normal/multiline comment stripping unchanged, ReDoS input (`"\n".repeat(40)+"x"`) completes in 0ms, mid-content `---` untouched
- Generated site output is **byte-identical** before/after (full `diff -r` of generated pages)
- `npm run build` (generate + astro build + rustdoc embed) passes
- Other `site/scripts/*.mjs` checked for the same patterns — none found