### PR TITLE
Configure BGE-M3 for 8192-token inputs

### DIFF
--- a/src/embedding/fastembed_impl.rs
+++ b/src/embedding/fastembed_impl.rs
@@ -52,6 +52,12 @@ impl FastEmbedEmbedder {
         })
     }
 
+    fn init_options() -> fastembed::InitOptions {
+        fastembed::InitOptions::new(fastembed::EmbeddingModel::BGEM3)
+            .with_max_length(8192)
+            .with_show_download_progress(false)
+    }
+
     /// Gets or initializes the embedding model (thread-safe).
     ///
     /// The model is loaded lazily on first use to preserve cold start time.
@@ -63,8 +69,7 @@ impl FastEmbedEmbedder {
         }
 
         // Initialize the model
-        let options = fastembed::InitOptions::new(fastembed::EmbeddingModel::BGEM3)
-            .with_show_download_progress(false);
+        let options = Self::init_options();
 
         let model = fastembed::TextEmbedding::try_new(options)
             .map_err(|e| StorageError::Embedding(format!("Failed to load embedding model: {e}")))?;
@@ -185,6 +190,11 @@ mod tests {
     fn test_model_name() {
         let embedder = FastEmbedEmbedder::new().unwrap();
         assert_eq!(embedder.model_name(), "BGE-M3");
+    }
+
+    #[test]
+    fn test_bge_m3_max_length() {
+        assert_eq!(FastEmbedEmbedder::init_options().max_length, 8192);
     }
 
     // Integration tests that require model download are marked #[ignore]


### PR DESCRIPTION
Fixes #302.

rlm-rs [ADR 10](https://github.com/zircote/rlm-rs/blob/v1.3.1/docs/adr/010-switch-to-bge-m3-model.md#L46-L56) states:

In the Background and Problem Statement
> ~512 token context often truncates larger chunks

And as a positive consequence:
> Full chunk coverage: 8192 tokens handles any reasonable chunk size

Yet the code was still pegged to 512 tokens rather than the 8192 desired max tokens MGE-M3 supports.

This PR fixes that by configuring BGE-M3 with an 8192-token maximum and add a focused assertion for the production init options.

Tested with the full Rust suite, strict Clippy, a >512-token BGE-M3 runtime check, and the ENCTX RLM harness.
