### PR TITLE
Preserve source metadata for code chunking

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -303,6 +303,17 @@ fn cmd_reset(db_path: &std::path::Path, yes: bool, _format: OutputFormat) -> Res
     Ok("RLM state reset successfully.\n".to_string())
 }
 
+fn chunker_metadata(buffer: &Buffer, chunk_size: usize, overlap: usize) -> ChunkerMetadata {
+    let mut metadata = ChunkerMetadata::with_size_and_overlap(chunk_size, overlap);
+    if let Some(source) = &buffer.source {
+        metadata = metadata.source(source.to_string_lossy().as_ref());
+    }
+    if let Some(content_type) = buffer.metadata.content_type.as_deref() {
+        metadata = metadata.content_type(content_type);
+    }
+    metadata
+}
+
 fn cmd_load(
     db_path: &std::path::Path,
     file: &std::path::Path,
@@ -331,7 +342,7 @@ fn cmd_load(
 
     // Chunk the content
     let chunker = create_chunker(chunker_name)?;
-    let meta = ChunkerMetadata::with_size_and_overlap(chunk_size, overlap);
+    let meta = chunker_metadata(&buffer, chunk_size, overlap);
     let chunks = chunker.chunk(buffer_id, &content, Some(&meta))?;
 
     // Store chunks
@@ -659,7 +670,7 @@ fn cmd_update_buffer(
 
     // Re-chunk the content
     let chunker = create_chunker(strategy)?;
-    let meta = ChunkerMetadata::with_size_and_overlap(chunk_size, overlap);
+    let meta = chunker_metadata(&updated_buffer, chunk_size, overlap);
     let chunks = chunker.chunk(buffer_id, &new_content, Some(&meta))?;
     let new_chunk_count = chunks.len();
     storage.add_chunks(buffer_id, &chunks)?;

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -670,7 +670,7 @@ fn cmd_update_buffer(
 
     // Re-chunk the content
     let chunker = create_chunker(strategy)?;
-    let meta = chunker_metadata(&updated_buffer, chunk_size, overlap);
+    let meta = ChunkerMetadata::with_size_and_overlap(chunk_size, overlap);
     let chunks = chunker.chunk(buffer_id, &new_content, Some(&meta))?;
     let new_chunk_count = chunks.len();
     storage.add_chunks(buffer_id, &chunks)?;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1724,6 +1724,50 @@ mod cli_tests {
     }
 
     #[test]
+    fn test_cmd_load_code_chunker_uses_source_extension() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let db_path = temp_dir.path().join("test.db");
+        let file_path = temp_dir.path().join("content.rs");
+        let content = format!(
+            "{}\npub struct Marker;\n{}\n",
+            "x".repeat(100),
+            "y".repeat(100)
+        );
+        std::fs::write(&file_path, &content).expect("write file");
+
+        let cli = make_cli(db_path.clone(), Commands::Init { force: false });
+        execute(&cli).expect("init");
+
+        let cli = make_cli(
+            db_path.clone(),
+            Commands::Load {
+                file: file_path,
+                name: Some("code".to_string()),
+                chunker: "code".to_string(),
+                chunk_size: 90,
+                overlap: 0,
+            },
+        );
+        execute(&cli).expect("load");
+
+        let cli = make_cli_json(
+            db_path,
+            Commands::Chunk(ChunkCommands::List {
+                buffer: "code".to_string(),
+                preview: false,
+                preview_len: 100,
+            }),
+        );
+        let chunks: serde_json::Value =
+            serde_json::from_str(&execute(&cli).expect("list chunks")).expect("chunk JSON");
+
+        assert_eq!(
+            chunks["chunks"][0]["byte_range"]["end"].as_u64(),
+            Some(content.find("pub struct Marker").expect("struct offset") as u64)
+        );
+    }
+
+    #[test]
     fn test_cmd_variable_not_found() {
         let temp_dir = TempDir::new().expect("temp dir");
         let db_path = temp_dir.path().join("test.db");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1724,7 +1724,7 @@ mod cli_tests {
     }
 
     #[test]
-    fn test_cmd_load_code_chunker_uses_source_extension() {
+    fn test_cmd_load_code_chunker_uses_buffer_language_metadata() {
         let temp_dir = TempDir::new().expect("temp dir");
         let db_path = temp_dir.path().join("test.db");
         let file_path = temp_dir.path().join("content.rs");


### PR DESCRIPTION
Addresses the `cmd_load` path of #304.

Pass buffer source and content type into `ChunkerMetadata` for CLI file loads so `CodeChunker` can select language-aware boundaries. Add a CLI-boundary regression assertion.

This PR intentionally leaves `cmd_update_buffer` on size-and-overlap-only metadata. Replacement content can come from inline input or stdin while the buffer retains its original source metadata, so propagating those language hints would apply stale rules to unrelated content.