### PR TITLE
Filter buffer candidates before search ranking

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1018,19 +1018,12 @@ fn cmd_dispatch(
             .with_top_k(chunks.len()) // Get all matches
             .with_threshold(threshold)
             .with_semantic(use_semantic)
-            .with_bm25(use_bm25);
+            .with_bm25(use_bm25)
+            .with_buffer(Some(buffer_id));
 
         let results = hybrid_search(&storage, embedder.as_ref(), query_str, &config)?;
 
-        // Filter to only chunks from this buffer
-        let buffer_chunk_ids: std::collections::HashSet<i64> =
-            chunks.iter().filter_map(|c| c.id).collect();
-
-        results
-            .into_iter()
-            .filter(|r| buffer_chunk_ids.contains(&r.chunk_id))
-            .map(|r| r.chunk_id)
-            .collect()
+        results.into_iter().map(|r| r.chunk_id).collect()
     } else {
         chunks.iter().filter_map(|c| c.id).collect()
     };
@@ -1133,13 +1126,6 @@ fn cmd_search(
         _ => (true, true), // hybrid is default
     };
 
-    let config = SearchConfig::new()
-        .with_top_k(top_k)
-        .with_threshold(threshold)
-        .with_rrf_k(rrf_k)
-        .with_semantic(use_semantic)
-        .with_bm25(use_bm25);
-
     // If buffer filter is specified, validate it exists
     let buffer_id = if let Some(identifier) = buffer_filter {
         let buffer = resolve_buffer(&storage, identifier)?;
@@ -1148,22 +1134,15 @@ fn cmd_search(
         None
     };
 
-    let results = hybrid_search(&storage, embedder.as_ref(), query, &config)?;
+    let config = SearchConfig::new()
+        .with_top_k(top_k)
+        .with_threshold(threshold)
+        .with_rrf_k(rrf_k)
+        .with_semantic(use_semantic)
+        .with_bm25(use_bm25)
+        .with_buffer(buffer_id);
 
-    // Filter by buffer if specified
-    let mut results: Vec<SearchResult> = if let Some(bid) = buffer_id {
-        let buffer_chunks: std::collections::HashSet<i64> = storage
-            .get_chunks(bid)?
-            .iter()
-            .filter_map(|c| c.id)
-            .collect();
-        results
-            .into_iter()
-            .filter(|r| buffer_chunks.contains(&r.chunk_id))
-            .collect()
-    } else {
-        results
-    };
+    let mut results = hybrid_search(&storage, embedder.as_ref(), query, &config)?;
 
     // Populate content previews if requested
     if preview {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -21,7 +21,9 @@ use crate::core::{Buffer, Context, ContextValue};
 use crate::embedding::create_embedder;
 use crate::error::{CommandError, Result, StorageError};
 use crate::io::{read_file, write_file};
-use crate::search::{SearchConfig, SearchResult, embed_buffer_chunks, hybrid_search};
+use crate::search::{
+    SearchConfig, SearchResult, embed_buffer_chunks, hybrid_search, hybrid_search_in_buffer,
+};
 use crate::storage::{SqliteStorage, Storage};
 use regex::RegexBuilder;
 use std::fmt::Write as FmtWrite;
@@ -1018,10 +1020,10 @@ fn cmd_dispatch(
             .with_top_k(chunks.len()) // Get all matches
             .with_threshold(threshold)
             .with_semantic(use_semantic)
-            .with_bm25(use_bm25)
-            .with_buffer(Some(buffer_id));
+            .with_bm25(use_bm25);
 
-        let results = hybrid_search(&storage, embedder.as_ref(), query_str, &config)?;
+        let results =
+            hybrid_search_in_buffer(&storage, embedder.as_ref(), query_str, &config, buffer_id)?;
 
         results.into_iter().map(|r| r.chunk_id).collect()
     } else {
@@ -1139,10 +1141,13 @@ fn cmd_search(
         .with_threshold(threshold)
         .with_rrf_k(rrf_k)
         .with_semantic(use_semantic)
-        .with_bm25(use_bm25)
-        .with_buffer(buffer_id);
+        .with_bm25(use_bm25);
 
-    let mut results = hybrid_search(&storage, embedder.as_ref(), query, &config)?;
+    let mut results = if let Some(buffer_id) = buffer_id {
+        hybrid_search_in_buffer(&storage, embedder.as_ref(), query, &config, buffer_id)?
+    } else {
+        hybrid_search(&storage, embedder.as_ref(), query, &config)?
+    };
 
     // Populate content previews if requested
     if preview {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,6 @@ pub use embedding::{
 // Re-export search types
 pub use search::{
     DEFAULT_SIMILARITY_THRESHOLD, DEFAULT_TOP_K, RrfConfig, SearchConfig, SearchResult,
-    buffer_fully_embedded, embed_buffer_chunks, hybrid_search, reciprocal_rank_fusion, search_bm25,
-    search_semantic, weighted_rrf,
+    buffer_fully_embedded, embed_buffer_chunks, hybrid_search, hybrid_search_in_buffer,
+    reciprocal_rank_fusion, search_bm25, search_semantic, weighted_rrf,
 };

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -57,8 +57,6 @@ pub struct SearchConfig {
     pub use_semantic: bool,
     /// Whether to include BM25 search.
     pub use_bm25: bool,
-    /// Optional buffer ID to restrict before ranking.
-    pub buffer_id: Option<i64>,
 }
 
 impl Default for SearchConfig {
@@ -69,7 +67,6 @@ impl Default for SearchConfig {
             rrf_k: 60,
             use_semantic: true,
             use_bm25: true,
-            buffer_id: None,
         }
     }
 }
@@ -189,13 +186,6 @@ impl SearchConfig {
         self.use_bm25 = enabled;
         self
     }
-
-    /// Restricts search to a single buffer before ranking.
-    #[must_use]
-    pub const fn with_buffer(mut self, buffer_id: Option<i64>) -> Self {
-        self.buffer_id = buffer_id;
-        self
-    }
 }
 
 /// Performs hybrid search combining semantic and BM25 results.
@@ -216,17 +206,50 @@ pub fn hybrid_search(
     query: &str,
     config: &SearchConfig,
 ) -> Result<Vec<SearchResult>> {
+    hybrid_search_scoped(storage, embedder, query, config, None)
+}
+
+/// Performs hybrid search restricted to a single buffer before ranking.
+///
+/// # Arguments
+///
+/// * `storage` - The storage backend.
+/// * `embedder` - The embedding generator.
+/// * `query` - The search query text.
+/// * `config` - Search configuration.
+/// * `buffer_id` - Buffer ID to restrict before semantic and BM25 ranking.
+///
+/// # Errors
+///
+/// Returns an error if search operations fail.
+pub fn hybrid_search_in_buffer(
+    storage: &SqliteStorage,
+    embedder: &dyn Embedder,
+    query: &str,
+    config: &SearchConfig,
+    buffer_id: i64,
+) -> Result<Vec<SearchResult>> {
+    hybrid_search_scoped(storage, embedder, query, config, Some(buffer_id))
+}
+
+fn hybrid_search_scoped(
+    storage: &SqliteStorage,
+    embedder: &dyn Embedder,
+    query: &str,
+    config: &SearchConfig,
+    buffer_id: Option<i64>,
+) -> Result<Vec<SearchResult>> {
     let mut semantic_results: Vec<(i64, f32)> = Vec::new();
     let mut bm25_results: Vec<(i64, f64)> = Vec::new();
 
     // Semantic search
     if config.use_semantic {
-        semantic_results = semantic_search(storage, embedder, query, config)?;
+        semantic_results = semantic_search(storage, embedder, query, config, buffer_id)?;
     }
 
     // BM25 search
     if config.use_bm25 {
-        bm25_results = storage.search_fts_in_buffer(query, config.top_k * 2, config.buffer_id)?;
+        bm25_results = storage.search_fts_in_buffer(query, config.top_k * 2, buffer_id)?;
     }
 
     // If only one type of search is enabled, return those results directly
@@ -288,39 +311,26 @@ fn semantic_search(
     embedder: &dyn Embedder,
     query: &str,
     config: &SearchConfig,
+    buffer_id: Option<i64>,
 ) -> Result<Vec<(i64, f32)>> {
     use rayon::prelude::*;
 
     // Generate query embedding
     let query_embedding = embedder.embed(query)?;
 
-    // Get all embeddings from storage
-    let all_embeddings = storage.get_all_embeddings()?;
+    // Get only the embeddings that can participate in this search.
+    let all_embeddings = match buffer_id {
+        Some(buffer_id) => storage.get_embeddings_in_buffer(buffer_id)?,
+        None => storage.get_all_embeddings()?,
+    };
 
     if all_embeddings.is_empty() {
         return Ok(Vec::new());
     }
 
-    let buffer_chunk_ids = config
-        .buffer_id
-        .map(|buffer_id| {
-            storage.get_chunks(buffer_id).map(|chunks| {
-                chunks
-                    .into_iter()
-                    .filter_map(|chunk| chunk.id)
-                    .collect::<std::collections::HashSet<_>>()
-            })
-        })
-        .transpose()?;
-
     // Calculate similarities in parallel (rayon data parallelism)
     let mut similarities: Vec<(i64, f32)> = all_embeddings
         .par_iter()
-        .filter(|(chunk_id, _)| {
-            buffer_chunk_ids
-                .as_ref()
-                .is_none_or(|ids| ids.contains(chunk_id))
-        })
         .map(|(chunk_id, embedding)| {
             let sim = cosine_similarity(&query_embedding, embedding);
             (*chunk_id, sim)
@@ -833,6 +843,8 @@ mod tests {
             add_single_chunk_buffer(&mut storage, "needle needle needle needle");
         let embedder = FallbackEmbedder::new(2);
         let query_embedding = embedder.embed("needle").unwrap();
+        // The target embedding is orthogonal to the query while the distractor
+        // matches, so this fails if buffer filtering happens after ranking.
         storage
             .store_embedding(
                 target_chunk,
@@ -847,19 +859,25 @@ mod tests {
         let bm25_config = SearchConfig::new()
             .with_top_k(1)
             .with_semantic(false)
-            .with_bm25(true)
-            .with_buffer(Some(target_buffer));
-        let bm25_results = hybrid_search(&storage, &embedder, "needle", &bm25_config).unwrap();
+            .with_bm25(true);
+        let bm25_results =
+            hybrid_search_in_buffer(&storage, &embedder, "needle", &bm25_config, target_buffer)
+                .unwrap();
         assert_eq!(bm25_results[0].chunk_id, target_chunk);
 
         let semantic_config = SearchConfig::new()
             .with_top_k(1)
             .with_threshold(-1.0)
             .with_semantic(true)
-            .with_bm25(false)
-            .with_buffer(Some(target_buffer));
-        let semantic_results =
-            hybrid_search(&storage, &embedder, "needle", &semantic_config).unwrap();
+            .with_bm25(false);
+        let semantic_results = hybrid_search_in_buffer(
+            &storage,
+            &embedder,
+            "needle",
+            &semantic_config,
+            target_buffer,
+        )
+        .unwrap();
         assert_eq!(semantic_results[0].chunk_id, target_chunk);
     }
 
@@ -973,7 +991,7 @@ mod tests {
         // Use a zero threshold to capture all results from the fallback embedder
         let config = SearchConfig::new().with_top_k(10).with_threshold(0.0);
 
-        let results = semantic_search(&storage, &embedder, "test query", &config).unwrap();
+        let results = semantic_search(&storage, &embedder, "test query", &config, None).unwrap();
 
         // Should return results (we embedded 3 chunks)
         assert!(!results.is_empty());
@@ -991,7 +1009,7 @@ mod tests {
         // Verify threshold filtering: with a very high threshold, results should be excluded
         let strict_config = SearchConfig::new().with_top_k(10).with_threshold(0.99);
         let strict_results =
-            semantic_search(&storage, &embedder, "test query", &strict_config).unwrap();
+            semantic_search(&storage, &embedder, "test query", &strict_config, None).unwrap();
 
         // Strict threshold should return fewer (or no) results
         assert!(

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -57,6 +57,8 @@ pub struct SearchConfig {
     pub use_semantic: bool,
     /// Whether to include BM25 search.
     pub use_bm25: bool,
+    /// Optional buffer ID to restrict before ranking.
+    pub buffer_id: Option<i64>,
 }
 
 impl Default for SearchConfig {
@@ -67,6 +69,7 @@ impl Default for SearchConfig {
             rrf_k: 60,
             use_semantic: true,
             use_bm25: true,
+            buffer_id: None,
         }
     }
 }
@@ -186,6 +189,13 @@ impl SearchConfig {
         self.use_bm25 = enabled;
         self
     }
+
+    /// Restricts search to a single buffer before ranking.
+    #[must_use]
+    pub const fn with_buffer(mut self, buffer_id: Option<i64>) -> Self {
+        self.buffer_id = buffer_id;
+        self
+    }
 }
 
 /// Performs hybrid search combining semantic and BM25 results.
@@ -216,7 +226,7 @@ pub fn hybrid_search(
 
     // BM25 search
     if config.use_bm25 {
-        bm25_results = storage.search_fts(query, config.top_k * 2)?;
+        bm25_results = storage.search_fts_in_buffer(query, config.top_k * 2, config.buffer_id)?;
     }
 
     // If only one type of search is enabled, return those results directly
@@ -291,9 +301,26 @@ fn semantic_search(
         return Ok(Vec::new());
     }
 
+    let buffer_chunk_ids = config
+        .buffer_id
+        .map(|buffer_id| {
+            storage.get_chunks(buffer_id).map(|chunks| {
+                chunks
+                    .into_iter()
+                    .filter_map(|chunk| chunk.id)
+                    .collect::<std::collections::HashSet<_>>()
+            })
+        })
+        .transpose()?;
+
     // Calculate similarities in parallel (rayon data parallelism)
     let mut similarities: Vec<(i64, f32)> = all_embeddings
         .par_iter()
+        .filter(|(chunk_id, _)| {
+            buffer_chunk_ids
+                .as_ref()
+                .is_none_or(|ids| ids.contains(chunk_id))
+        })
         .map(|(chunk_id, embedding)| {
             let sim = cosine_similarity(&query_embedding, embedding);
             (*chunk_id, sim)
@@ -620,7 +647,7 @@ pub fn embed_buffer_chunks_incremental(
 mod tests {
     use super::*;
     use crate::core::{Buffer, Chunk};
-    use crate::embedding::{DEFAULT_DIMENSIONS, FallbackEmbedder};
+    use crate::embedding::{DEFAULT_DIMENSIONS, Embedder, FallbackEmbedder};
     use crate::storage::Storage;
 
     fn setup_storage() -> SqliteStorage {
@@ -664,6 +691,25 @@ mod tests {
         storage.add_chunks(buffer_id, &chunks).unwrap();
 
         storage
+    }
+
+    fn add_single_chunk_buffer(storage: &mut SqliteStorage, content: &str) -> (i64, i64) {
+        let buffer_id = storage
+            .add_buffer(&Buffer::from_content(content.to_string()))
+            .unwrap();
+        storage
+            .add_chunks(
+                buffer_id,
+                &[Chunk::new(
+                    buffer_id,
+                    content.to_string(),
+                    0..content.len(),
+                    0,
+                )],
+            )
+            .unwrap();
+        let chunk_id = storage.get_chunks(buffer_id).unwrap()[0].id.unwrap();
+        (buffer_id, chunk_id)
     }
 
     #[test]
@@ -777,6 +823,44 @@ mod tests {
         assert!(!results.is_empty());
         assert!(results[0].bm25_score.is_some());
         assert!(results[0].semantic_score.is_none());
+    }
+
+    #[test]
+    fn test_buffer_filter_applies_before_ranking() {
+        let mut storage = setup_storage();
+        let (target_buffer, target_chunk) = add_single_chunk_buffer(&mut storage, "needle");
+        let (_, distractor_chunk) =
+            add_single_chunk_buffer(&mut storage, "needle needle needle needle");
+        let embedder = FallbackEmbedder::new(2);
+        let query_embedding = embedder.embed("needle").unwrap();
+        storage
+            .store_embedding(
+                target_chunk,
+                &[-query_embedding[1], query_embedding[0]],
+                Some("query-test"),
+            )
+            .unwrap();
+        storage
+            .store_embedding(distractor_chunk, &query_embedding, Some("query-test"))
+            .unwrap();
+
+        let bm25_config = SearchConfig::new()
+            .with_top_k(1)
+            .with_semantic(false)
+            .with_bm25(true)
+            .with_buffer(Some(target_buffer));
+        let bm25_results = hybrid_search(&storage, &embedder, "needle", &bm25_config).unwrap();
+        assert_eq!(bm25_results[0].chunk_id, target_chunk);
+
+        let semantic_config = SearchConfig::new()
+            .with_top_k(1)
+            .with_threshold(-1.0)
+            .with_semantic(true)
+            .with_bm25(false)
+            .with_buffer(Some(target_buffer));
+        let semantic_results =
+            hybrid_search(&storage, &embedder, "needle", &semantic_config).unwrap();
+        assert_eq!(semantic_results[0].chunk_id, target_chunk);
     }
 
     #[test]

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -884,6 +884,21 @@ impl SqliteStorage {
     /// Returns an error if the search fails.
     #[allow(clippy::cast_possible_wrap)]
     pub fn search_fts(&self, query: &str, limit: usize) -> Result<Vec<(i64, f64)>> {
+        self.search_fts_in_buffer(query, limit, None)
+    }
+
+    /// Performs FTS5 BM25 full-text search, optionally restricted to a buffer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the search fails.
+    #[allow(clippy::cast_possible_wrap)]
+    pub fn search_fts_in_buffer(
+        &self,
+        query: &str,
+        limit: usize,
+        buffer_id: Option<i64>,
+    ) -> Result<Vec<(i64, f64)>> {
         // FTS5 bm25() returns negative scores, more negative = better match
         // We negate it so higher scores = better match
 
@@ -902,15 +917,16 @@ impl SqliteStorage {
                 r"
                 SELECT rowid, -bm25(chunks_fts) as score
                 FROM chunks_fts
-                WHERE chunks_fts MATCH ?
+                WHERE chunks_fts MATCH ?1
+                  AND (?2 IS NULL OR rowid IN (SELECT id FROM chunks WHERE buffer_id = ?2))
                 ORDER BY score DESC
-                LIMIT ?
+                LIMIT ?3
             ",
             )
             .map_err(StorageError::from)?;
 
         let results = stmt
-            .query_map(params![fts_query, limit as i64], |row| {
+            .query_map(params![fts_query, buffer_id, limit as i64], |row| {
                 Ok((row.get::<_, i64>(0)?, row.get::<_, f64>(1)?))
             })
             .map_err(StorageError::from)?

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -911,27 +911,49 @@ impl SqliteStorage {
             .collect::<Vec<_>>()
             .join(" OR ");
 
-        let mut stmt = self
-            .conn
-            .prepare(
-                r"
-                SELECT rowid, -bm25(chunks_fts) as score
-                FROM chunks_fts
-                WHERE chunks_fts MATCH ?1
-                  AND (?2 IS NULL OR rowid IN (SELECT id FROM chunks WHERE buffer_id = ?2))
-                ORDER BY score DESC
-                LIMIT ?3
-            ",
-            )
-            .map_err(StorageError::from)?;
+        let results = if let Some(buffer_id) = buffer_id {
+            let mut stmt = self
+                .conn
+                .prepare(
+                    r"
+                    SELECT chunks_fts.rowid, -bm25(chunks_fts) as score
+                    FROM chunks_fts
+                    INNER JOIN chunks ON chunks.id = chunks_fts.rowid
+                    WHERE chunks_fts MATCH ?1
+                      AND chunks.buffer_id = ?2
+                    ORDER BY score DESC
+                    LIMIT ?3
+                ",
+                )
+                .map_err(StorageError::from)?;
 
-        let results = stmt
-            .query_map(params![fts_query, buffer_id, limit as i64], |row| {
+            stmt.query_map(params![fts_query, buffer_id, limit as i64], |row| {
                 Ok((row.get::<_, i64>(0)?, row.get::<_, f64>(1)?))
             })
             .map_err(StorageError::from)?
             .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(StorageError::from)?;
+            .map_err(StorageError::from)?
+        } else {
+            let mut stmt = self
+                .conn
+                .prepare(
+                    r"
+                    SELECT rowid, -bm25(chunks_fts) as score
+                    FROM chunks_fts
+                    WHERE chunks_fts MATCH ?1
+                    ORDER BY score DESC
+                    LIMIT ?2
+                ",
+                )
+                .map_err(StorageError::from)?;
+
+            stmt.query_map(params![fts_query, limit as i64], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, f64>(1)?))
+            })
+            .map_err(StorageError::from)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StorageError::from)?
+        };
 
         Ok(results)
     }
@@ -949,6 +971,41 @@ impl SqliteStorage {
 
         let results = stmt
             .query_map([], |row| {
+                let chunk_id: i64 = row.get(0)?;
+                let bytes: Vec<u8> = row.get(1)?;
+                let embedding: Vec<f32> = bytes
+                    .chunks_exact(4)
+                    .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+                    .collect();
+                Ok((chunk_id, embedding))
+            })
+            .map_err(StorageError::from)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(StorageError::from)?;
+
+        Ok(results)
+    }
+
+    /// Returns chunk embeddings belonging to one buffer for vector similarity search.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub fn get_embeddings_in_buffer(&self, buffer_id: i64) -> Result<Vec<(i64, Vec<f32>)>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                r"
+                SELECT ce.chunk_id, ce.embedding
+                FROM chunk_embeddings ce
+                INNER JOIN chunks c ON c.id = ce.chunk_id
+                WHERE c.buffer_id = ?
+            ",
+            )
+            .map_err(StorageError::from)?;
+
+        let results = stmt
+            .query_map(params![buffer_id], |row| {
                 let chunk_id: i64 = row.get(0)?;
                 let bytes: Vec<u8> = row.get(1)?;
                 let embedding: Vec<f32> = bytes
@@ -1572,9 +1629,30 @@ mod tests {
         storage
             .store_embedding(chunk_id2, &[0.2_f32], Some("m"))
             .unwrap();
+        let (other_buffer_id, other_chunk_id) = setup_buffer_with_chunk(&mut storage);
+        storage
+            .store_embedding(other_chunk_id, &[0.3_f32], Some("m"))
+            .unwrap();
 
         let all = storage.get_all_embeddings().unwrap();
-        assert_eq!(all.len(), 2);
+        assert_eq!(all.len(), 3);
+
+        let scoped = storage.get_embeddings_in_buffer(buffer_id).unwrap();
+        assert_eq!(scoped.len(), 2);
+        assert!(scoped.iter().any(|(chunk_id, _)| *chunk_id == chunk_id1));
+        assert!(scoped.iter().any(|(chunk_id, _)| *chunk_id == chunk_id2));
+        assert!(
+            !scoped
+                .iter()
+                .any(|(chunk_id, _)| *chunk_id == other_chunk_id)
+        );
+        assert!(
+            storage
+                .get_embeddings_in_buffer(other_buffer_id)
+                .unwrap()
+                .iter()
+                .any(|(chunk_id, _)| *chunk_id == other_chunk_id)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #305.

Scope semantic and BM25 candidates to the requested buffer before ranking and truncation. Add one focused regression test.