### PR TITLE
fix(deps): bump anyhow and crossbeam-epoch to resolve RustSec advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert_cmd"
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

`cargo deny check` was failing the `advisories` check on `main` due to two open RustSec advisories in the dependency tree. This bumps the two affected crates to their minimum satisfying (fixed) versions.

## Related Issues

Fixes #311

## Changes

- Bumped `anyhow` 1.0.102 -> 1.0.103 (fixes RUSTSEC-2026-0190: unsoundness in `Error::downcast_mut()` that violates borrow rules and can cause UB when `Error::context` is used and the returned `Error` is later downcast).
- Bumped `crossbeam-epoch` 0.9.18 -> 0.9.20 (fixes RUSTSEC-2026-0204: invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid, e.g. a null pointer).
- Both were applied via `cargo update -p anyhow -p crossbeam-epoch`; only `Cargo.lock` changed. The existing `anyhow = "1.0.102"` direct dependency constraint in `Cargo.toml` already admits 1.0.103, so no manifest edit was needed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

### Test Commands Run

```bash
cargo fmt -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
cargo doc --no-deps
cargo deny check
```

All pass. `cargo deny check` now exits 0 with `advisories ok, bans ok, licenses ok, sources ok` (the two pre-existing non-fatal `duplicate` warnings for `base64` and `hashbrown`, and the `license-not-encountered` warning for `BSD-3-Clause`, are unrelated to this issue and were already called out as non-blocking cleanup items in #311).

### Manual Testing

N/A — dependency version bump only, no source code changes.

## Checklist

### Code Quality

- [x] My code follows the project's code style (rustfmt)
- [x] I have run `cargo clippy` and fixed all warnings
- [x] I have run `cargo fmt` to format my code
- [x] No unsafe code is added
- [x] No `unwrap()`, `expect()`, or `panic!()` in library code

### Testing

- [x] New and existing tests pass locally with `cargo test`
- [ ] I have added tests that prove my fix/feature works — not applicable; this is a transitive dependency version bump with no behavioral code change to test.

### Documentation

- [ ] N/A — no public API or documentation changes.

### Supply Chain

- [x] I have run `cargo deny check` and resolved any issues
- [x] No new security advisories are introduced
- [x] New dependencies are justified and from trusted sources (crates.io, existing deps bumped to patched versions)

### Commit Hygiene

- [x] My commits follow conventional commit format
- [x] I have rebased on the latest main branch
- [x] I have squashed fixup commits

## Additional Notes

Both dependencies are transitive (pulled in via `fastembed`, `rayon`, and `criterion`), and `anyhow` is also a direct dependency of `rlm-cli`. No further action is needed beyond the lockfile update.
