### PR TITLE
docs: regenerate site content to resync workflows/ref-package-homebrew

### DIFF
--- a/site/src/content/docs/workflows/ref-package-homebrew.mdx
+++ b/site/src/content/docs/workflows/ref-package-homebrew.mdx
@@ -13,6 +13,7 @@ sidebar:
 
 | Event |
 |---|
+| `workflow_run` |
 | `release` |
 | `workflow_dispatch` |
 


### PR DESCRIPTION
## Summary

Regenerates the Starlight docs site content to resync it with its source, as flagged by the automated docs-freshness workflow.

## Related Issues

Fixes #258

## Changes

- Ran `cd site && npm run generate` to regenerate all site content pages
- Only `site/src/content/docs/workflows/ref-package-homebrew.mdx` was out of sync: it was missing the `workflow_run` trigger row, which was added to `.github/workflows/package-homebrew.yml`'s `on:` block but never regenerated into the docs page
- No other generated pages changed

## Type of Change

- [x] Documentation update

## Testing

### Test Commands Run

```bash
cargo fmt -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
cargo doc --no-deps
cargo deny check
```

All passed. This is a docs-only change under `site/`; no Rust source was touched.

### Manual Testing

Ran `cd site && npm run generate` and confirmed the resulting diff was a single-line addition matching the `workflow_run` trigger already present in `.github/workflows/package-homebrew.yml`, with no other files touched.

## Checklist

### Code Quality

- [x] I have run `cargo clippy` and fixed all warnings
- [x] I have run `cargo fmt` to format my code
- [x] No unsafe code is added
- [x] No `unwrap()`, `expect()`, or `panic!()` in library code

### Testing

- [x] New and existing tests pass locally with `cargo test`

### Documentation

- [x] I have updated the documentation accordingly (regenerated, not hand-edited)

### Supply Chain

- [x] I have run `cargo deny check` and resolved any issues (pre-existing warnings only, unrelated to this change; advisories/bans/licenses/sources all ok)

### Commit Hygiene

- [x] I have rebased on the latest main branch
