### PR TITLE
docs: fix template placeholders and MSRV version

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@ This document provides context for GitHub Copilot when working with this Rust pr
 ## Project Context
 
 This is a Rust crate using modern tooling:
-- **Rust**: 1.80+ (2024 edition)
+- **Rust**: 1.95+ (2024 edition)
 - **Build System**: Cargo
 - **Linting**: clippy with pedantic and nursery lints
 - **Formatting**: rustfmt
@@ -87,12 +87,12 @@ Use doc comments with examples:
 /// # Examples
 ///
 /// ```rust
-/// use {{crate_name}}::{process, Config};
+/// use rlm_rs::{process, Config};
 ///
 /// let items = vec!["a", "b", "c"];
 /// let config = Config::default();
 /// let result = process(&items, &config)?;
-/// # Ok::<(), {{crate_name}}::Error>(())
+/// # Ok::<(), rlm_rs::Error>(())
 /// ```
 pub fn process(items: &[&str], config: &Config) -> Result<Vec<Item>> {
     // implementation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-{{crate_name}} is a Rust crate built with modern tooling, strict type safety, and zero-cost abstractions.
+rlm_rs is a Rust crate built with modern tooling, strict type safety, and zero-cost abstractions.
 
 ## Project Structure
 
@@ -75,7 +75,7 @@ This project uses **clippy** with pedantic and nursery lints, and **rustfmt** fo
 
 - **Line length**: 100 characters
 - **Edition**: 2024
-- **MSRV**: 1.80
+- **MSRV**: 1.95
 - **Unsafe code**: Forbidden unless explicitly justified
 - **Panics**: Not allowed in library code (`unwrap`, `expect`, `panic!`)
 
@@ -140,11 +140,11 @@ All public items must have documentation with examples:
 /// # Examples
 ///
 /// ```rust
-/// use {{crate_name}}::{process, Config};
+/// use rlm_rs::{process, Config};
 ///
 /// let result = process("data", &Config::default())?;
 /// assert!(!result.is_empty());
-/// # Ok::<(), {{crate_name}}::Error>(())
+/// # Ok::<(), rlm_rs::Error>(())
 /// ```
 pub fn process(input: &str, config: &Config) -> Result<Output, Error> {
     // implementation


### PR DESCRIPTION
## Summary

Fixes documentation issues identified in [Daily QA report 2026-03-29](https://github.com/zircote/rlm-rs/discussions/178) and confirmed still present after [2026-06-13](https://github.com/zircote/rlm-rs/discussions/257). This supersedes the prior automated fix attempt (#256) whose push failed.

- **`CLAUDE.md`**: replace 3 occurrences of the leftover scaffold placeholder `{{crate_name}}` with `rlm_rs`, and bump the documented MSRV from `1.80` to `1.95` to match `Cargo.toml`'s `rust-version`.
- **`.github/copilot-instructions.md`**: replace 2 occurrences of `{{crate_name}}` with `rlm_rs`, and bump the documented Rust version from `1.80+` to `1.95+`.

No other files were touched; the diff is scoped exactly to what issue #259 specifies.

## Human review required

> [!CAUTION]
> This PR modifies protected files (`CLAUDE.md`, `.github/copilot-instructions.md`), as flagged by issue #259. Per that issue, this change requires **explicit human review before merge** — please look closely at both diffs even though the edits are simple text substitutions.

## Verification

Ran the full local check suite from this repo's `CLAUDE.md`:

- `cargo fmt -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test` — 88 passed, 20 doc-tests passed
- `cargo doc --no-deps` — clean
- `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok` (pre-existing, unrelated warnings only)

Fixes #259
