### PR TITLE
chore(release): v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-15
+
 ### Fixed
 
+- **Embedding**: BGE-M3's FastEmbed initialization now sets `max_length` to
+  its real 8192-token context instead of inheriting fastembed's silent
+  512-token default — semantic indexing no longer truncates every chunk to
+  512 tokens on embed, which had been producing silently degraded vectors
+  ([#303](https://github.com/zircote/rlm-rs/pull/303))
 - **Chunking**: `MAX_CHUNK_SIZE` lowered from 50,000 to 24,000 bytes —
   token-dense text can run well under the ~4 bytes/token assumed by the old ceiling,
   so chunks under 50,000 bytes could still exceed BGE-M3's 8192-token limit and get
@@ -289,7 +296,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Variable storage (context and global)
 - Export functionality
 
-[Unreleased]: https://github.com/zircote/rlm-rs/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/zircote/rlm-rs/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/zircote/rlm-rs/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/zircote/rlm-rs/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/zircote/rlm-rs/compare/v1.2.4...v1.3.0
 [1.2.4]: https://github.com/zircote/rlm-rs/compare/v1.2.3...v1.2.4

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ abstract: >-
   tasks via chunking and recursive sub-LLM calls. Implements hybrid semantic
   and BM25 search with Reciprocal Rank Fusion, code-aware chunking, and
   pass-by-reference chunk retrieval for efficient subagent processing.
-version: 1.3.1
-date-released: 2026-06-12
+version: 1.4.0
+date-released: 2026-07-15
 license: MIT
 url: "https://github.com/zircote/rlm-rs"
 repository-code: "https://github.com/zircote/rlm-rs"
@@ -33,8 +33,8 @@ preferred-citation:
   abstract: >-
     Recursive Language Model (RLM) CLI for Claude Code - handles long-context
     tasks via chunking and recursive sub-LLM calls.
-  version: 1.3.1
-  date-released: 2026-06-12
+  version: 1.4.0
+  date-released: 2026-07-15
   license: MIT
   url: "https://github.com/zircote/rlm-rs"
   repository-code: "https://github.com/zircote/rlm-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "rlm-cli"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlm-cli"
-version = "1.3.1"
+version = "1.4.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Recursive Language Model (RLM) REPL for Claude Code - handles long-context tasks via chunking and recursive sub-LLM calls"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ gh attestation verify rlm-cli-<version>-<platform> --repo zircote/rlm-rs
 For example:
 
 ```sh
-gh attestation verify rlm-cli-1.3.1-linux-amd64 --repo zircote/rlm-rs
+gh attestation verify rlm-cli-1.4.0-linux-amd64 --repo zircote/rlm-rs
 ```
 
 A successful verification prints `✓ Verification succeeded!` and confirms


### PR DESCRIPTION
## Summary

Minor release bumping `rlm-cli` to v1.4.0. Updates all five version-tracked locations (`Cargo.toml`/`Cargo.lock`, `CHANGELOG.md`, `CITATION.cff` — both fields, `SECURITY.md` example).

## Contents (from CHANGELOG)

### Fixed
- **Embedding**: BGE-M3's FastEmbed initialization now sets `max_length` to its real 8192-token context instead of inheriting fastembed's silent 512-token default — semantic indexing no longer truncates every chunk to 512 tokens on embed (#303)
- **Chunking**: `MAX_CHUNK_SIZE` lowered from 50,000 to 24,000 bytes to stay under BGE-M3's 8192-token embedding limit for token-dense text (#313)

### Added
- **Tooling**: project-local `/release` Claude Code skill orchestrating the full attested release pipeline

## Testing

`cargo fmt -- --check` and `cargo check` pass locally. Full gauntlet (test/clippy/audit/doc) runs via this PR's CI and the release workflow's own gates.

## Operator notes

Once merged, tag `v1.4.0` on the merge commit to trigger the attested release, crates.io publish, and Homebrew formula update.
