### PR TITLE
fix(ci): give cargo audit its own advisory-db path, v1.4.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,12 @@ jobs:
           cargo test --all-features --locked
           cargo doc --no-deps --all-features --locked
           cargo deny check
-          cargo audit
+          # deny.toml pins its advisory-db to ~/.cargo/advisory-db (cargo
+          # audit's own default path); running both tools against the same
+          # path in one job has cargo audit refuse to re-clone into the
+          # directory cargo deny already populated. Point audit at its own
+          # path to avoid the collision.
+          cargo audit --db ~/.cargo/advisory-db-audit
 
       - name: Dry run publish
         run: cargo publish --dry-run --allow-dirty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-07-15
+
+### Fixed
+
+- **CI**: `publish.yml` failed to publish v1.4.1 to crates.io — `deny.toml`
+  pins its advisory-db to `~/.cargo/advisory-db`, the same default path
+  `cargo audit` uses, so running `cargo deny check` then `cargo audit` in the
+  same job step had audit refuse to re-clone into the directory deny had
+  already populated. `cargo audit` now points at a separate `--db` path so
+  the two tools no longer collide. v1.4.1 shipped a GitHub Release and
+  Homebrew update but never reached crates.io because of this; v1.4.2 is the
+  first version to complete the full pipeline including the crates.io
+  publish.
+
 ## [1.4.1] - 2026-07-15
 
 ### Fixed
@@ -313,7 +327,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Variable storage (context and global)
 - Export functionality
 
-[Unreleased]: https://github.com/zircote/rlm-rs/compare/v1.4.1...HEAD
+[Unreleased]: https://github.com/zircote/rlm-rs/compare/v1.4.2...HEAD
+[1.4.2]: https://github.com/zircote/rlm-rs/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/zircote/rlm-rs/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/zircote/rlm-rs/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/zircote/rlm-rs/compare/v1.3.0...v1.3.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ abstract: >-
   tasks via chunking and recursive sub-LLM calls. Implements hybrid semantic
   and BM25 search with Reciprocal Rank Fusion, code-aware chunking, and
   pass-by-reference chunk retrieval for efficient subagent processing.
-version: 1.4.1
+version: 1.4.2
 date-released: 2026-07-15
 license: MIT
 url: "https://github.com/zircote/rlm-rs"
@@ -33,7 +33,7 @@ preferred-citation:
   abstract: >-
     Recursive Language Model (RLM) CLI for Claude Code - handles long-context
     tasks via chunking and recursive sub-LLM calls.
-  version: 1.4.1
+  version: 1.4.2
   date-released: 2026-07-15
   license: MIT
   url: "https://github.com/zircote/rlm-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "rlm-cli"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlm-cli"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2024"
 rust-version = "1.95"
 description = "Recursive Language Model (RLM) REPL for Claude Code - handles long-context tasks via chunking and recursive sub-LLM calls"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ gh attestation verify rlm-cli-<version>-<platform> --repo zircote/rlm-rs
 For example:
 
 ```sh
-gh attestation verify rlm-cli-1.4.1-linux-amd64 --repo zircote/rlm-rs
+gh attestation verify rlm-cli-1.4.2-linux-amd64 --repo zircote/rlm-rs
 ```
 
 A successful verification prints `✓ Verification succeeded!` and confirms


### PR DESCRIPTION
## Summary

Patch release fixing the CI bug that caused v1.4.1 to publish a GitHub Release and update Homebrew, but never reach crates.io.

## What happened

- v1.4.1's `publish.yml` run failed at "Run pre-publish checks" — twice in a row (confirmed via `gh run rerun --failed`), with `cargo audit` erroring: `Refusing to initialize the non-empty directory as '~/.cargo/advisory-db'`.
- Root cause: `deny.toml` pins `db-path = "~/.cargo/advisory-db"` for its own advisory checks — the exact same default path `cargo audit` uses. `publish.yml`'s pre-publish-checks step runs `cargo deny check` then `cargo audit` back-to-back in the same job; deny populates that path first, and audit's fetch logic refuses to clone into the now-non-empty directory.
- `release.yml` and `ci.yml` each run only one of the two tools per job, so neither hit this — it was specific to `publish.yml` running both together.
- Net effect: v1.4.1 has a GitHub Release (binaries, SBOM, attestations) and an updated Homebrew formula, but was never published to crates.io. quinn-proto was already fixed in v1.4.1's `Cargo.lock` (RUSTSEC-2026-0185) — this PR does not touch that, only the workflow bug that blocked its publish.

## Changes

- `publish.yml`: `cargo audit` now runs against its own `--db ~/.cargo/advisory-db-audit` path so it no longer collides with `cargo deny check`'s path.
- Version bump to v1.4.2 across all five tracked locations.

## Testing

Reproduced locally: after `cargo deny check` populates `~/.cargo/advisory-db`, plain `cargo audit` fails identically; `cargo audit --db ~/.cargo/advisory-db-audit` succeeds cleanly. `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-features` all pass locally.

## Operator notes

Once merged, tag `v1.4.2` on the merge commit. This should be the first version in this saga to complete the full pipeline: GitHub Release, crates.io, and Homebrew.
